### PR TITLE
Currency field removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ Check the script example that automates data history uploads to a forked reposit
 [ui]: /ui.md
 [ui_chart_pine]: /images/ui_chart_pine_btc.png
 [ui_symbol_search]: /ui.md#symbol-search
-[update_script]: /update_example/update_exhamle.md
+[update_script]: /update_example/update_example.md

--- a/data.md
+++ b/data.md
@@ -72,9 +72,9 @@ The object consists of the following required fields:
 
 | Field | Type | Description | Note |
 |-|-|-|-|
-| `symbol` | String | Symbol name used in TradingView. | Cannot be empty. Validation rule: `^[A-Z0-9._]+$`. |
-| `description` | String | Symbol description. | Cannot be empty. |
-| `pricescale` | Integer | Indicates how many decimal places the price has. | The value format is `10^n`, where *n* is the number of decimal places. For example, if the price has two decimal places `300.01`, set `pricescale` to `100`. If it has three decimal places `300.001`, set `pricescale` to `1000`, etc. If the price doesn't have decimals, set `pricescale` to `1`. |
+| `symbol` | String | Symbol name used in TradingView. | Cannot be empty. Validation rule: `^[A-Z0-9._]+$`. The maximum number of characters in the symbol must be 42. |
+| `description` | String | Symbol description. | Cannot be empty. The maximum number of characters in the description must be 128. |
+| `pricescale` | Integer | Indicates how many decimal places the price has. | The value format is `10^n`, where *n* is the number of decimal places. For example, if the price has two decimal places `300.01`, set `pricescale` to `100`. If it has three decimal places `300.001`, set `pricescale` to `1000`, etc. If the price doesn't have decimals, set `pricescale` to `1`. The maximum value of the pricescale must be 10000000000000000000000 (22 zeroes). |
 
 > __Note__
 > 

--- a/data.md
+++ b/data.md
@@ -73,7 +73,6 @@ The object consists of the following required fields:
 | Field | Type | Description | Note |
 |-|-|-|-|
 | `symbol` | String | Symbol name used in TradingView. | Cannot be empty. Validation rule: `^[A-Z0-9._]+$`. |
-| `currency` | String | Three-letter currency code according to [ISO 4217][iso_4217]. | Can be empty. Validation rule: `^[A-Z0-9._]+$`. |
 | `description` | String | Symbol description. | Cannot be empty. |
 | `pricescale` | Integer | Indicates how many decimal places the price has. | The value format is `10^n`, where *n* is the number of decimal places. For example, if the price has two decimal places `300.01`, set `pricescale` to `100`. If it has three decimal places `300.001`, set `pricescale` to `1000`, etc. If the price doesn't have decimals, set `pricescale` to `1`. |
 
@@ -81,7 +80,7 @@ The object consists of the following required fields:
 > 
 > Each object field is an array with values.
 > For all fields, the length of these arrays must match.
-> However, if all the values in the array are the same, you can specify a single value for the field instead of an array.
+> However, if all the values in the array are the same in the `pricescale` field, you can specify a single value for the field instead of an array.
 
 Consider the following example.
 If you specify three symbols in the object, 
@@ -95,7 +94,6 @@ then you also need to specify three descriptions, three price scales, and three 
       "ETH_DEV_ACTIVITY"
    ],
    "pricescale": [10, 10, 10],
-   "currency": "",
    "description": [
       "Bitcoin developer activity",
       "Bitcoin social volume total",
@@ -115,7 +113,6 @@ However, if all added symbols have the same price scale, you can only specify a 
       "ETH_DEV_ACTIVITY"
    ],
    "pricescale": 10,
-   "currency": "",
    "description": [
       "Bitcoin developer activity",
       "Bitcoin social volume total",

--- a/data_tutorial.md
+++ b/data_tutorial.md
@@ -38,8 +38,10 @@ This tutorial describes the steps to add symbols to the TradingView chart at onc
 If you need to remove a symbol and its data, you should follow the steps below:
 
 1. Remove the information about a symbol from the JSON file in the `symbol_info/repo_name.json` directory
-2. Delete a CSV file with symbol data from the `data/` directory.
-3. In your repository, open *Actions* and check if the `Check data` action finished successfully.
-4. In the main repository, open *Actions* and check if the `Upload data` action finished successfully. Go to *Pull requests* and check that the pull request was merged automatically.
+2. In your repository, open Actions and check if the Check data action finished successfully.
+3. In the main repository, open Actions and check if the Upload data action finished successfully.
+4. Delete a CSV file with symbol data from the `data/` directory.
+5. In your repository, open *Actions* and check if the `Check data` action finished successfully.
+6. In the main repository, open *Actions* and check if the `Upload data` action finished successfully. Go to *Pull requests* and check that the pull request was merged automatically.
 
 [tv-chart]: https://www.tradingview.com/chart/

--- a/repo.md
+++ b/repo.md
@@ -19,7 +19,7 @@ The results of the data checks will be available in the action logs.
 Send us an email to pine.seeds@tradingview.com with the subject __Pine Seeds Request__.
 Specify your GitHub username and the desired repository suffix.
 Note that the maximum number of characters in the suffix must be 16.
-The repository name will be `seed_<your_github_username>_<suffix_you_provided>`.
+The repository name will be `seed_<your_github_username>_<suffix_you_provided>`. The maximum number of characters in the whole repository name must be 64.
 
 > __Note__
 >


### PR DESCRIPTION
+ Note corrected as only one field (`pricescale`) can be shorten into scalar value. Fields `symbol` and `description` must be always arrays with the same length.